### PR TITLE
Update copyright date 2026

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ _site
 
 # Bundler
 vendor/bundle
+
+# macOS
+.DS_Store
+
+# Local temporary files
+tmp/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2025 Julio Trigo
+Copyright (c) 2017-2026 Julio Trigo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/_config.yml
+++ b/_config.yml
@@ -50,7 +50,7 @@ excerpt_link_text: ...read more
 minima:
   date_format: "%b %-d, %Y"
 
-copyright: Copyright © 2013-2025 Julio Vicente Trigo Guijarro
+copyright: Copyright © 2013-2026 Julio Vicente Trigo Guijarro
 license_link_text: License &amp; copyright
 powered_by: >
   Powered by <a href="https://www.netlify.com/">Netlify</a>

--- a/docs/2025-12-08-performance-improvement-plan.md
+++ b/docs/2025-12-08-performance-improvement-plan.md
@@ -12,7 +12,7 @@ This plan addresses the performance issues identified by PageSpeed Insights for 
 | 4 | Fix `<html lang>` attribute | ✅ Completed (2025-12-08) |
 | 5 | Enable CSS minification | ✅ Completed (2025-12-08) |
 | 6 | Optimize images (optional) | ⏳ Pending |
-| 7 | Preload Lato font to reduce critical chain | ⏳ Pending |
+| 7 | Preload Lato fonts to reduce critical chain | ✅ Completed (2025-12-10) |
 
 ---
 
@@ -315,6 +315,18 @@ Pages using only Regular (no bold/italic): `index.md`, `articles.md`, `bookmarks
 2. The homepage is lightweight and fast anyway
 3. 134 KB is relatively small on modern connections
 4. Preloading only Regular would still leave Bold as the critical path bottleneck on blog posts
+
+**Testing (2025-12-10):**
+
+1. Built site with `bundle exec jekyll build` - ✅ Success
+2. Verified generated HTML contains all 4 preload links - ✅ Present
+3. Tested locally with `bundle exec jekyll serve` - ✅ Working
+4. PageSpeed results for Ruby blog post:
+   - **Before:** Maximum critical path latency 1,085ms (fonts in chain)
+   - **After:** Maximum critical path latency 897ms (fonts removed from chain)
+   - **Improvement:** ~188ms reduction in critical path latency
+
+**Note:** The remaining HTML → CSS chain (897ms) is unavoidable and cannot be optimised with preloading. CSS is already discovered immediately in the `<head>`, so preloading it would be redundant. This chain represents the minimum critical path for any web page.
 
 ---
 

--- a/license-copyright.md
+++ b/license-copyright.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: License & copyright
-last_modified_at: 2025-12-07 14:30:00 +0100
+last_modified_at: 2026-01-01 12:00:00 +0100
 permalink: /license-copyright/
 ---
 


### PR DESCRIPTION
- Update copyright and license year to 2026
- Performance improvement plan:
  - Mark preload Lato fonts as done
  - Add new steps
- Add new patterns to `.gitignore`